### PR TITLE
Fixing for product list now including vehicles (KeyError)

### DIFF
--- a/tesla_api/__init__.py
+++ b/tesla_api/__init__.py
@@ -91,7 +91,9 @@ class TeslaApiClient:
         return [Vehicle(self, vehicle) for vehicle in self.get('vehicles')]
 
     def list_energy_sites(self):
-        return [Energy(self, products['energy_site_id']) for products in self.get('products')]
+        prods = self.get('products')
+        energy_items = [item for item in prods if 'energy_site_id' in item]
+        return [Energy(self, item['energy_site_id']) for item in energy_items]
 
 class AuthenticationError(Exception):
     def __init__(self, error):


### PR DESCRIPTION
Current solution gives a KeyError if you have vehicle(s) and Powerwall(s) - as the key list is different.